### PR TITLE
Add CCP-AHC Town Hall 2026 information

### DIFF
--- a/docs/activities/town-hall-2026/index.md
+++ b/docs/activities/town-hall-2026/index.md
@@ -1,0 +1,41 @@
+# CCP-AHC Town Hall 2026 - Overview
+
+## Date and Time
+
+Thursday, 17 September 2026, 9:30 a.m. to 4:00 p.m.
+
+An optional training session will be held on the afternoon of Wednesday, 16 September 2026 in FAIR practices for research software in the arts, humanities and culture domain.
+
+## Location
+
+UKRI STFC Rutherford Appleton Labs, Oxfordshire
+
+Hybrid participation for at least part of the event will be facilitated.
+
+## About the event
+
+### Purpose and overview
+
+The purpose of the CCP-AHC Town Hall 2026 is to bring together representatives of:
+
+-	national and international digital research infrastructure (DRI) initiatives supporting arts, humanities, and culture (AHC) research and innovation;
+-	DRI professionals who enable and empower this work, particularly those interested in or actively using large-scale compute, including HPC, cloud, and other advanced-computing infrastructures;
+-	the UK HPC and advanced computing community, including members of existing CCPs;
+-	expertise in sustainable computationally intensive AHC research and the FAIR data, workflows, and software that support it;
+-	leaders in engaged and inclusive design principles for access to DRI.
+
+Delegates will receive brief presentations on key topics, including updates from the project and presentations from community members.
+
+Attendees will also work collaboratively to refine the [the CCP-AHC Roadmap Open Draft](https://zenodo.org/records/17099176), based on the experience of current community members, the evolving DRI landscape, and recent developments in research policy.
+
+### Expression of Interest
+
+If you have reason to believe that your work has the potential to produce a compelling use case for large-scale compute and other related DRI or to be used by a broader set of researchers and innovators, please express your interest in joining us in Durham in May.
+
+[Express interest in attending CCP-AHC Town Hall 2026 (opening soon)](){ .md-button .md-button--primary } 
+
+## Cost
+
+There is no cost to attending the CCP-AHC Town Hall 2026. Travel and accommodation costs will, in general, not be covered by CCP-AHC. 
+
+Bursaries to facilitate participation in the FAIR software training are available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ We invite the community involved in computationally-intensive arts, humanities, 
 
 ### Future
 
-The CCP-AHC Town Hall 2026 will take place on Thursday, 17 September 2026 at UKRI STFC Rutherford Appleton Labs in Oxfordshire, with an optional training session on the afternoon of 16 September. Hybrid attendance at the part of the Town Hall will be facilitated.
+The [CCP-AHC Town Hall 2026](./activities/town-hall-2026/index.md) will take place on Thursday, 17 September 2026 at UKRI STFC Rutherford Appleton Labs in Oxfordshire, with an optional training session on the afternoon of 16 September. Hybrid attendance at the part of the Town Hall will be facilitated.
 
 ### Past
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,8 @@ nav:
       - CCP-AHC Town Hall 2025:
             - activities/town-hall-2025/index.md
             - Agenda: activities/town-hall-2025/agenda.md
+      - CCP-AHC Town Hall 2026:
+            - activities/town-hall-2026/index.md
   - Blog: blog/index.md
   - Resources:
       - Tools: resources/tools.md


### PR DESCRIPTION
- Adds a new page for the Town Hall 2026
- Adds links to front page
- Amends navigation to link to info page for Town Hall 2026